### PR TITLE
history, review 모델 수정

### DIFF
--- a/review/models.py
+++ b/review/models.py
@@ -11,7 +11,7 @@ class Problem(models.Model) :
 class History(models.Model) :
     user_id= models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
     problem_id= models.ForeignKey(Problem, on_delete=models.CASCADE)
-    name= models.CharField(max_length=25)
+    name= models.CharField(max_length=255)
     type= models.SmallIntegerField()
     source_code= models.TextField()
     created_at= models.DateTimeField(default=datetime.now())
@@ -19,7 +19,7 @@ class History(models.Model) :
 
 class Review(models.Model) :
     history_id= models.ForeignKey(History, on_delete=models.CASCADE)
-    title= models.CharField(max_length=50)
+    title= models.CharField(max_length=255)
     content= models.TextField()
     start_line_number= models.SmallIntegerField()
     end_line_number= models.SmallIntegerField()


### PR DESCRIPTION
히스토리 저장 로직은 history.name을 첫 번째 review.title을 저장하는 로직입니다.
모델에선 기존 
history.name 길이 25제한,
review.title 길이 50제한, 으로
두 컬럼의 길이 제한이 상이하여 발생한 모델 저장에 오류가 발생했습니다.
이 오류를 조치하고자, 두 컬럼의 길이를 255로 정정했습니다.
