### PR TITLE
feat: Add revision tracking for code review history

### DIFF
--- a/review/models.py
+++ b/review/models.py
@@ -14,6 +14,7 @@ class History(models.Model) :
     name= models.CharField(max_length=255)
     type= models.SmallIntegerField()
     source_code= models.TextField()
+    revision = models.PositiveIntegerField(default=1)
     created_at= models.DateTimeField(default=datetime.now())
     is_deleted= models.BooleanField(default=False)
 


### PR DESCRIPTION
Feat: 코드 리뷰 히스토리에 revision 데이터 추가
- History 테이블에 리뷰 횟수 조회를 위한 revision 컬럼 추가
- revision 데이터 처리를 위한 API 엔드포인트 수정:
  - [POST] /api/v1/review: 리뷰 횟수 계산 및 응답 로직 추가
  - [GET] /api/v1/histories/{history_id}: 상세 조회 시 revision 정보 포함